### PR TITLE
Pretty display for JSON

### DIFF
--- a/vocprez/view/templates/_format.html
+++ b/vocprez/view/templates/_format.html
@@ -19,6 +19,8 @@ Output:
         <a href="{{ s }}">{{ s }}</a>
     {% elif markdown %}
         {{ utils.parse_markdown(s)|safe }}
+    {% elif s.startswith("{") %}
+        <pre>{{ s|safe }}</pre>
     {% elif safe %}
         {{ s|safe }}
     {% else %}

--- a/vocprez/view/templates/concept.html
+++ b/vocprez/view/templates/concept.html
@@ -1,4 +1,5 @@
 {% extends "page.html" %}
+{% from "_format.html" import format with context -%}
 {% block content %}
 
 <h1>Concept</h1>
@@ -35,7 +36,7 @@
   {% endif %}
   <tr>
     <th><a href="http://www.w3.org/2004/02/skos/core#definition">Definition</a></th>
-    <td>{{ concept.definition }}</td>
+      <td>{{ format(concept.definition)|safe }}</td>
   </tr>
   {% if concept.related_instances|length > 0 %}
     {% for k, v in concept.related_instances.items() %}


### PR DESCRIPTION
Added pretty formatting for JSON to the formatting styles (_format.py). Added the formatting as an import to concept.html. Can be added to other templates in the same way.

@nicholascar Could you please invite me to the VocPrez repo again, the previous invite expired