### PR TITLE
Add README to Dockerfile (for 'About' page)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY requirements.txt .
 
 RUN pip install -r requirements.txt
 
+COPY README.md .
 ADD ./vocprez ./vocprez
 
 CMD ["gunicorn", "-w", "5", "-b", "0.0.0.0:5000", "vocprez.wsgi:app"]


### PR DESCRIPTION
One-line change to copy the README into the docker container, as the About page depends on it being present.

You can see how we're overriding it in a custom theme here:
https://github.com/BritishGeologicalSurvey/VocPrez-theme-BGS/pull/1




