### PR TITLE
Add GH actions & Add gunicorn logs to stdout and stderr

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,55 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - released
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: vocprez
+
+jobs:
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+
+      - name: Log in to registry
+        # This is where you will update the PAT to GITHUB_TOKEN
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "main" ] && VERSION=latest
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ COPY README.md .
 COPY wsgi.py .
 #COPY ./deploy ./vocprez
 
-CMD ["gunicorn", "-w", "5", "-b", "0.0.0.0:5000", "wsgi:application"]
+CMD ["gunicorn", "-w", "5", "-b", "0.0.0.0:5000",  "--access-logfile", "-", "--error-logfile", "-", "wsgi:application"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ RUN pip install -r requirements.deploy.txt
 
 COPY README.md .
 COPY wsgi.py .
-COPY ./deploy ./vocprez
+#COPY ./deploy ./vocprez
 
 CMD ["gunicorn", "-w", "5", "-b", "0.0.0.0:5000", "wsgi:application"]

--- a/Dockerfile.Example
+++ b/Dockerfile.Example
@@ -1,0 +1,4 @@
+FROM ghcr.io/RDFLib/VocPrez:latest
+
+COPY vocprez/_config/template.py /vocprez/_config/__init__.py
+


### PR DESCRIPTION
Add GH Actions to build container & push to GH container registry (GH eqiv of DockerHub)

master branch > latest tag
releases > tagged as release number

Example: https://github.com/BritishGeologicalSurvey/VocPrez/pkgs/container/vocprez 

Then users can pull directly and copy in their config with Dockerfile - no docker-compose required.  

```
FROM ghcr.io/RDFLib/VocPrez:latest

COPY vocprez/_config/template.py /vocprez/_config/__init__.py
```

Also Send gunicorn logs to stdout and stderr so they are saved in container logs